### PR TITLE
Add image lightbox

### DIFF
--- a/evolveum-jekyll-theme/_layouts/default.html
+++ b/evolveum-jekyll-theme/_layouts/default.html
@@ -28,6 +28,7 @@
         <script src="/assets/js/evolveum/site-review.js"></script>
         <script src="/assets/js/evolveum/initialize-tables.js"></script>
         <script src="/assets/js/evolveum/navtree-expand.js"></script>
+        <script src="/assets/js/evolveum/lightboxize.js"></script>
         <!--- <script src="/assets/js/evolveum/rag-test.js"></script> --->
 
         <script type="text/x-mathjax-config">

--- a/evolveum-jekyll-theme/_sass/evolveum.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum.scss
@@ -9,3 +9,4 @@
 @import "evolveum/review";
 @import "evolveum/hacks";
 @import "evolveum/datatables";
+@import "evolveum/lightbox";

--- a/evolveum-jekyll-theme/_sass/evolveum/_base.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_base.scss
@@ -252,7 +252,6 @@ div.page-meta {
 }
 
 img {
-    max-width: 100%;
     height: auto;
 }
 

--- a/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
@@ -10,12 +10,9 @@
     max-width: 40vw;
   }
   @media (max-width: 1280px) {
-    max-width: 60vw;
+    max-width: 70vw;
   }
-  @media (max-width: 800px) {
-    max-width: 80vw;
-  }
-  @media (max-width: 500px) {
+  @media (max-width: 768px) {
     max-width: 90vw;
   }
 }

--- a/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
@@ -65,7 +65,7 @@
   background: #fff;
   color: #000;
   font-size: 100%;
-  width: calc(100% - 0.8em);
+  width: 100%;
   overflow: scroll;
   padding: 0.4em;
   margin: 0 auto;

--- a/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
@@ -80,9 +80,9 @@
   text-align: left;
   background: #fff;
   color: #000;
+  max-width: initial;
   font-size: 100%;
-  width: 100%;
-  overflow: scroll;
+  overflow-y: scroll;
   padding: 0.4em;
   margin: 0 auto;
   border-top: 1px solid #00000066;

--- a/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
@@ -1,6 +1,7 @@
 .image-in-content {
   max-width: 300px;
   margin: 1em;
+  cursor: pointer;
 }
 
 .image-in-content-link {
@@ -23,7 +24,6 @@
   border: none;
   background: #00000044;
   backdrop-filter: blur(10px) grayscale(90%) contrast(70%);
-  font-size: 2vw;
   text-align: center;
 }
 
@@ -34,12 +34,10 @@
   transform: translate(-50%, -50%);
   max-width: 90%;
   max-height: 90%;
-  overflow: hidden;
   z-index: 257;
   border: none;
 
   .image-in-lightbox {
-    box-shadow: 0 0 4em 0.7em #000000bb;
     background: #111;
   }
   .image-in-lb-fit-size {
@@ -56,6 +54,22 @@
       cursor: grabbing;
     }
   }
+}
+
+#lightbox-fence {
+  overflow: hidden;
+}
+
+.image-in-content-label {
+  text-align: left;
+  background: #fff;
+  color: #000;
+  font-size: 100%;
+  width: calc(100% - 0.8em);
+  overflow: scroll;
+  padding: 0.4em;
+  margin: 0 auto;
+  border-top: 1px solid #00000066;
 }
 
 #image-lightbox-close-btn {
@@ -82,3 +96,4 @@
   left: 0;
   z-index: 256;
 }
+

--- a/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
@@ -92,9 +92,13 @@
   font-size: 30px;
   cursor: pointer;
   color: #000;
+  background: #fff;
+  height: 1lh;
+  width: 1lh;
   position: absolute;
-  top: 0px;
-  right: 0.5em;
+  top: calc(-1lh - 1px);
+  right: 0em;
+  border-bottom: 1px solid #00000066;
   z-index: 257;
   text-shadow:
     2px 0 2px #fff,
@@ -112,4 +116,3 @@
   left: 0;
   z-index: 256;
 }
-

--- a/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
@@ -1,7 +1,23 @@
 .image-in-content {
-  max-width: 300px;
+  max-width: 20vw;
   margin: 1em;
   cursor: pointer;
+
+  @media (max-width: 3000px) {
+    max-width: 30vw;
+  }
+  @media (max-width: 2000px) {
+    max-width: 40vw;
+  }
+  @media (max-width: 1280px) {
+    max-width: 60vw;
+  }
+  @media (max-width: 800px) {
+    max-width: 80vw;
+  }
+  @media (max-width: 500px) {
+    max-width: 90vw;
+  }
 }
 
 .image-in-content-link {

--- a/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
@@ -1,0 +1,84 @@
+.image-in-content {
+  max-width: 300px;
+  margin: 1em;
+}
+
+.image-in-content-link {
+  text-decoration: none;
+}
+
+.image-in-content-label {
+  text-decoration: none;
+  color: #000;
+}
+
+#image-lightbox-wrapper {
+  display: none;
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 255;
+  border: none;
+  background: #00000044;
+  backdrop-filter: blur(10px) grayscale(90%) contrast(70%);
+  font-size: 2vw;
+  text-align: center;
+}
+
+#image-lightbox {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 90%;
+  max-height: 90%;
+  overflow: hidden;
+  z-index: 257;
+  border: none;
+
+  .image-in-lightbox {
+    box-shadow: 0 0 4em 0.7em #000000bb;
+    background: #111;
+  }
+  .image-in-lb-fit-size {
+    max-width: 90vw;
+    max-height: 90vh;
+  }
+  .image-in-lb-zoomed-size {
+    position: relative;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    left: 50%;
+    cursor: grab;
+    &:active {
+      cursor: grabbing;
+    }
+  }
+}
+
+#image-lightbox-close-btn {
+  font-size: 30px;
+  cursor: pointer;
+  color: #000;
+  position: absolute;
+  top: 0px;
+  right: 0.5em;
+  z-index: 257;
+  text-shadow:
+    2px 0 2px #fff,
+    0 -2px 2px #fff,
+    -2px 0 2px #fff,
+    0 2px 2px #fff;
+}
+
+#lightbox-killing-floor {
+  display: none;
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 256;
+}

--- a/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
+++ b/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
@@ -1,5 +1,8 @@
 const images = document.querySelectorAll('img');
 
+const labelEl = document.createElement('p');
+labelEl.setAttribute('class', 'image-in-content-label');
+
 const fitSizeClass = 'image-in-lb-fit-size';
 const zoomedSizeClass = 'image-in-lb-zoomed-size';
 
@@ -28,9 +31,14 @@ const lightbox = document.createElement('div');
 lightbox.setAttribute('id', 'image-lightbox');
 lightbox.appendChild(lightboxCloseButton);
 
+const lightboxFence = document.createElement('div');
+lightboxFence.setAttribute('id', 'lightbox-fence');
+
+lightbox.appendChild(lightboxFence);
+
 lightboxWrapper.appendChild(lightbox);
 
-function openLightbox(image) {
+function openLightbox(image, imageLabel) {
     document.getElementById('image-lightbox-wrapper').style.display = 'block';
     lightboxKillingFloor.style.display = 'block';
 
@@ -40,10 +48,13 @@ function openLightbox(image) {
 
     const lightboxChildren = lightbox.childNodes;
     lightboxChildren.forEach(child => {
-        if (child.nodeName == 'IMG') {
+        if (child.nodeName == 'IMG' || child.nodeName == 'P') {
             lightbox.removeChild(child);
         }
     });
+
+    // Create label for the image and fill it with the alt text
+    labelEl.innerHTML = (imageLabel);
 
     if (image.src.includes('.svg')) {
         lightboxWidth = '90vw';
@@ -52,11 +63,23 @@ function openLightbox(image) {
     else {
         lightboxWidth = image.width + 'px';
     }
-    document.getElementById('image-lightbox').appendChild(image);
+    document.getElementById('lightbox-fence').appendChild(image);
+    if (imageLabel) {
+        image.parentNode.parentNode.appendChild(labelEl);
+    }
     document.getElementById('image-lightbox').style.display = 'block';
     document.body.style.overflow = 'hidden';
+
     lightbox.style.width = image.clientWidth + 'px';
     lightbox.style.height = image.clientHeight + 'px';
+
+    lightboxFence.style.width = image.clientWidth + 'px';
+    lightboxFence.style.height = image.clientHeight + 'px';
+
+    // Make sure the label is not higher than the ( viewport height minus image height ) divided by two
+    // The magical value of 50 is uncomfortable but needed.
+    // The solution is very suboptimal, it would be better to move the image higher and if that would not be enough, make it smaller.
+    labelEl.style.maxHeight = (window.innerHeight - image.clientHeight - 30) / 2 + 'px';
 
     // Determine whether to allow zoom&pan - if the lightbox is of the same size as the image 100% size, then do not allow zoom&pan
     if ((image.clientWidth < image.naturalWidth) || (image.clientHeight < image.naturalHeight)) {
@@ -260,17 +283,17 @@ images.forEach(img => {
     link.setAttribute('title', img.alt || '');
     link.setAttribute('class', 'image-in-content-link');
 
-    // Create label for the image and fill it with the alt text
-    const label = document.createElement('div');
-    label.innerHTML = (img.alt || '');
-    label.setAttribute('class', 'image-in-content-label');
+    let imageLabel = '';
+    if (img.parentNode.nextElementSibling) {
+        imageLabel = img.parentNode.nextElementSibling.innerHTML;
+    }
 
     // Add class
     img.setAttribute('class', 'image-in-content');
     const imgInLB = img.cloneNode();
     imgInLB.setAttribute('id', 'active-lightboxed-image');
     img.addEventListener('click', function() {
-        openLightbox(imgInLB);
+        openLightbox(imgInLB, imageLabel);
     });
 
     // Replace the image with the anchor element
@@ -278,5 +301,5 @@ images.forEach(img => {
 
     // Append the image inside the anchor
     link.appendChild(img);
-    link.appendChild(label);
+    // link.appendChild(labelEl);
 });

--- a/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
+++ b/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
@@ -79,13 +79,13 @@ function openLightbox(image) {
     function handleDoubleTap(e) {
         const currentTime = new Date().getTime();
         const tapLength = currentTime - lastTapTime;
-        
+
         if (tapLength < 300 && tapLength > 0) {
             // Prevent default to stop potential zooming or other default behaviors
             e.preventDefault();
             zoomImageInLightbox(image);
         }
-        
+
         lastTapTime = currentTime;
     }
 
@@ -115,7 +115,7 @@ function closeLightbox() {
 function zoomImageInLightbox(boxedImage) {
     boxedImage.classList.toggle(fitSizeClass);
     boxedImage.classList.toggle(zoomedSizeClass);
-    
+
     if (boxedImage.classList.contains(zoomedSizeClass)) {
         setupImagePanning(boxedImage);
     } else {
@@ -146,35 +146,35 @@ function setupImagePanning(image) {
     function startDrag(e) {
         // Prevent default for both mouse and touch events
         e.preventDefault();
-        
+
         // Only handle primary mouse button for mouse events
         if (e.type === 'mousedown' && e.button !== 0) return;
-        
+
         isDragging = true;
-        
+
         // Get coordinates
         const event = getEventCoordinates(e);
-        
+
         // Record the initial position
         startX = event.clientX;
         startY = event.clientY;
-        
+
         image.style.cursor = 'grabbing';
     }
 
     function drag(e) {
         if (!isDragging) return;
-        
+
         // Prevent default scrolling during drag
         e.preventDefault();
-        
+
         // Get coordinates
         const event = getEventCoordinates(e);
-        
+
         // Calculate the difference in movement
         const deltaX = event.clientX - startX;
         const deltaY = event.clientY - startY;
-        
+
         // Update total translation
         translateX = image.initialTranslation.x + deltaX;
         translateY = image.initialTranslation.y + deltaY;
@@ -194,14 +194,14 @@ function setupImagePanning(image) {
         if (translateY < (-image.height + (lightboxHeight / 2))) {
             translateY = (-image.height + (lightboxHeight / 2))
         }
-        
+
         // Apply translation
         image.style.transform = `translate(${translateX}px, ${translateY}px)`;
-        
+
         // Update the initial translation to the new position
         image.initialTranslation.x = translateX;
         image.initialTranslation.y = translateY;
-        
+
         // Reset start position for next move
         startX = event.clientX;
         startY = event.clientY;
@@ -238,9 +238,9 @@ function removeImagePanning(image) {
         image.panningListeners.forEach(event => {
             event.target.removeEventListener(event.type, event.listener);
         });
-        
+
         image.style.cursor = '';
-        
+
         // Reset transform and remove stored translation
         image.style.transform = '';
         delete image.initialTranslation;
@@ -251,7 +251,11 @@ function removeImagePanning(image) {
 images.forEach(img => {
     // Create a new anchor element
     const link = document.createElement('a');
-    
+
+    // Remove the hardcoded width attribute which comes probably from the template and conflicts with the lightbox
+    // (and, in general, seems unneeded).
+    img.removeAttribute('width');
+
     // Optionally, add a title or alt text
     link.setAttribute('title', img.alt || '');
     link.setAttribute('class', 'image-in-content-link');
@@ -271,7 +275,7 @@ images.forEach(img => {
 
     // Replace the image with the anchor element
     img.parentNode.replaceChild(link, img);
-    
+
     // Append the image inside the anchor
     link.appendChild(img);
     link.appendChild(label);

--- a/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
+++ b/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
@@ -1,0 +1,278 @@
+const images = document.querySelectorAll('img');
+
+const fitSizeClass = 'image-in-lb-fit-size';
+const zoomedSizeClass = 'image-in-lb-zoomed-size';
+
+const lightboxWrapper = document.createElement('div');
+lightboxWrapper.setAttribute('id', 'image-lightbox-wrapper');
+
+document.body.appendChild(lightboxWrapper);
+
+const lightboxCloseButton = document.createElement('div');
+lightboxCloseButton.innerHTML = '×';
+lightboxCloseButton.setAttribute('id', 'image-lightbox-close-btn');
+lightboxCloseButton.setAttribute('title', 'Close the image lightbox');
+lightboxCloseButton.addEventListener('click', function() {
+    closeLightbox();
+});
+
+const lightboxKillingFloor = document.createElement('div');
+lightboxKillingFloor.setAttribute('id', 'lightbox-killing-floor');
+lightboxKillingFloor.addEventListener('click', function() {
+    closeLightbox();
+});
+
+lightboxWrapper.appendChild(lightboxKillingFloor);
+
+const lightbox = document.createElement('div');
+lightbox.setAttribute('id', 'image-lightbox');
+lightbox.appendChild(lightboxCloseButton);
+
+lightboxWrapper.appendChild(lightbox);
+
+function openLightbox(image) {
+    document.getElementById('image-lightbox-wrapper').style.display = 'block';
+    lightboxKillingFloor.style.display = 'block';
+
+    image.classList.remove('image-in-content');
+    image.classList.add('image-in-lightbox');
+    image.classList.add('image-in-lb-fit-size');
+
+    const lightboxChildren = lightbox.childNodes;
+    lightboxChildren.forEach(child => {
+        if (child.nodeName == 'IMG') {
+            lightbox.removeChild(child);
+        }
+    });
+
+    if (image.src.includes('.svg')) {
+        lightboxWidth = '90vw';
+        image.style.width = '90vw';
+    }
+    else {
+        lightboxWidth = image.width + 'px';
+    }
+    document.getElementById('image-lightbox').appendChild(image);
+    document.getElementById('image-lightbox').style.display = 'block';
+    document.body.style.overflow = 'hidden';
+    lightbox.style.width = image.clientWidth + 'px';
+    lightbox.style.height = image.clientHeight + 'px';
+
+    // Determine whether to allow zoom&pan - if the lightbox is of the same size as the image 100% size, then do not allow zoom&pan
+    if ((image.clientWidth < image.naturalWidth) || (image.clientHeight < image.naturalHeight)) {
+        image.setAttribute('title', 'Double-click to toggle zoom');
+        image.style.cursor = 'zoom-in';
+        image.ondblclick = function() {
+            zoomImageInLightbox(image);
+        }
+        image.ontouchend = function(event) {
+            handleDoubleTap(event);
+        }
+    }
+    else {
+        console.log("Zooming not possible, image too small.");
+    }
+
+    // Improved double-tap/double-click handling
+    let lastTapTime = 0;
+
+    function handleDoubleTap(e) {
+        const currentTime = new Date().getTime();
+        const tapLength = currentTime - lastTapTime;
+        
+        if (tapLength < 300 && tapLength > 0) {
+            // Prevent default to stop potential zooming or other default behaviors
+            e.preventDefault();
+            zoomImageInLightbox(image);
+        }
+        
+        lastTapTime = currentTime;
+    }
+
+    // Add both mouse and touch event listeners
+    // image.addEventListener('dblclick', handleDoubleTap);
+    // image.addEventListener('touchend', handleDoubleTap);
+}
+
+function closeLightbox() {
+    let lightboxedImageToClose = document.getElementById('active-lightboxed-image');
+    if (lightboxedImageToClose.classList.contains(zoomedSizeClass)) {
+        removeImagePanning(lightboxedImageToClose);
+    }
+    lightboxedImageToClose.classList.remove(zoomedSizeClass);
+    lightboxedImageToClose.classList.remove(fitSizeClass);
+    lightboxedImageToClose.removeAttribute('style');
+    lightboxedImageToClose.remove();
+
+    document.getElementById('image-lightbox-wrapper').style.display = 'none';
+    lightboxKillingFloor.style.display = 'none';
+
+    document.body.style.overflow = 'auto';
+    document.getElementById('image-lightbox').style.display = 'none';
+    event.stopPropagation();
+}
+
+function zoomImageInLightbox(boxedImage) {
+    boxedImage.classList.toggle(fitSizeClass);
+    boxedImage.classList.toggle(zoomedSizeClass);
+    
+    if (boxedImage.classList.contains(zoomedSizeClass)) {
+        setupImagePanning(boxedImage);
+    } else {
+        removeImagePanning(boxedImage);
+        boxedImage.style.cursor = 'zoom-in';
+    }
+}
+
+function setupImagePanning(image) {
+    let isDragging = false;
+    let startX, startY;
+    let translateX = 0, translateY = 0;
+
+    // Ensure initial translation is set up
+    if (!image.initialTranslation) {
+        const rect = image.getBoundingClientRect();
+        image.initialTranslation = {
+            x: -rect.width / 2,
+            y: -rect.height / 2
+        };
+    }
+
+    function getEventCoordinates(e) {
+        // Support both mouse and touch events
+        return e.touches ? e.touches[0] : e;
+    }
+
+    function startDrag(e) {
+        // Prevent default for both mouse and touch events
+        e.preventDefault();
+        
+        // Only handle primary mouse button for mouse events
+        if (e.type === 'mousedown' && e.button !== 0) return;
+        
+        isDragging = true;
+        
+        // Get coordinates
+        const event = getEventCoordinates(e);
+        
+        // Record the initial position
+        startX = event.clientX;
+        startY = event.clientY;
+        
+        image.style.cursor = 'grabbing';
+    }
+
+    function drag(e) {
+        if (!isDragging) return;
+        
+        // Prevent default scrolling during drag
+        e.preventDefault();
+        
+        // Get coordinates
+        const event = getEventCoordinates(e);
+        
+        // Calculate the difference in movement
+        const deltaX = event.clientX - startX;
+        const deltaY = event.clientY - startY;
+        
+        // Update total translation
+        translateX = image.initialTranslation.x + deltaX;
+        translateY = image.initialTranslation.y + deltaY;
+
+        // Prevent panning the image beyond the visible lightbox borders
+        lightboxWidth = image.parentNode.clientWidth;
+        lightboxHeight = image.parentNode.clientHeight;
+        if (translateX > (-lightboxWidth / 2)) {
+            translateX = (-lightboxWidth / 2)
+        }
+        if (translateY > (-lightboxHeight / 2)) {
+            translateY = (-lightboxHeight / 2)
+        }
+        if (translateX < (-image.width + (lightboxWidth / 2))) {
+            translateX = (-image.width + (lightboxWidth / 2))
+        }
+        if (translateY < (-image.height + (lightboxHeight / 2))) {
+            translateY = (-image.height + (lightboxHeight / 2))
+        }
+        
+        // Apply translation
+        image.style.transform = `translate(${translateX}px, ${translateY}px)`;
+        
+        // Update the initial translation to the new position
+        image.initialTranslation.x = translateX;
+        image.initialTranslation.y = translateY;
+        
+        // Reset start position for next move
+        startX = event.clientX;
+        startY = event.clientY;
+    }
+
+    function stopDrag() {
+        isDragging = false;
+        image.style.cursor = 'grab';
+    }
+
+    // Set initial cursor style
+    image.style.cursor = 'grab';
+
+    // Add event listeners for both mouse and touch events
+    const mouseEvents = [
+        { type: 'mousedown', listener: startDrag, target: image },
+        { type: 'touchstart', listener: startDrag, target: image },
+        { type: 'mousemove', listener: drag, target: document },
+        { type: 'touchmove', listener: drag, target: document },
+        { type: 'mouseup', listener: stopDrag, target: document },
+        { type: 'touchend', listener: stopDrag, target: document }
+    ];
+
+    // Store and add listeners
+    image.panningListeners = mouseEvents.map(event => {
+        event.target.addEventListener(event.type, event.listener, { passive: false });
+        return event;
+    });
+}
+
+function removeImagePanning(image) {
+    if (image.panningListeners) {
+        // Remove all stored event listeners
+        image.panningListeners.forEach(event => {
+            event.target.removeEventListener(event.type, event.listener);
+        });
+        
+        image.style.cursor = '';
+        
+        // Reset transform and remove stored translation
+        image.style.transform = '';
+        delete image.initialTranslation;
+    }
+}
+
+// Loop through each image
+images.forEach(img => {
+    // Create a new anchor element
+    const link = document.createElement('a');
+    
+    // Optionally, add a title or alt text
+    link.setAttribute('title', img.alt || '');
+    link.setAttribute('class', 'image-in-content-link');
+
+    // Create label for the image and fill it with the alt text
+    const label = document.createElement('div');
+    label.innerHTML = (img.alt || '');
+    label.setAttribute('class', 'image-in-content-label');
+
+    // Add class
+    img.setAttribute('class', 'image-in-content');
+    const imgInLB = img.cloneNode();
+    imgInLB.setAttribute('id', 'active-lightboxed-image');
+    img.addEventListener('click', function() {
+        openLightbox(imgInLB);
+    });
+
+    // Replace the image with the anchor element
+    img.parentNode.replaceChild(link, img);
+    
+    // Append the image inside the anchor
+    link.appendChild(img);
+    link.appendChild(label);
+});

--- a/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
+++ b/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
@@ -1,16 +1,22 @@
+// Enumerate all images in the page
 const images = document.querySelectorAll('img');
 
-const labelEl = document.createElement('p');
-labelEl.setAttribute('class', 'image-in-content-label');
-
+// Classes for unzoomed (fit size) and zoomed image (zooming by double click in the lightbox)
 const fitSizeClass = 'image-in-lb-fit-size';
 const zoomedSizeClass = 'image-in-lb-zoomed-size';
 
+// Create persistent DOM elements for the lightbox - used for any image in the page
+// The image label
+const labelEl = document.createElement('p');
+labelEl.setAttribute('class', 'image-in-content-label');
+
+// The wrapper covering the whole viewport and blurring the background of displayed lightbox
 const lightboxWrapper = document.createElement('div');
 lightboxWrapper.setAttribute('id', 'image-lightbox-wrapper');
 
 document.body.appendChild(lightboxWrapper);
 
+// The lightbox closing button
 const lightboxCloseButton = document.createElement('div');
 lightboxCloseButton.innerHTML = '×';
 lightboxCloseButton.setAttribute('id', 'image-lightbox-close-btn');
@@ -19,6 +25,7 @@ lightboxCloseButton.addEventListener('click', function() {
     closeLightbox();
 });
 
+// Element in the wrapper but beneath the lightbox element to enable closing the lightbox when user clicks the blurred lightbox background
 const lightboxKillingFloor = document.createElement('div');
 lightboxKillingFloor.setAttribute('id', 'lightbox-killing-floor');
 lightboxKillingFloor.addEventListener('click', function() {
@@ -27,10 +34,15 @@ lightboxKillingFloor.addEventListener('click', function() {
 
 lightboxWrapper.appendChild(lightboxKillingFloor);
 
+// The lightbox
 const lightbox = document.createElement('div');
 lightbox.setAttribute('id', 'image-lightbox');
 lightbox.appendChild(lightboxCloseButton);
 
+// Separate bounding box for the lightbox inside the lightbox element
+// It has to be separate to
+// - prevent zoomed image from overflowing the lightbox
+// - but enable closing button and label be beyond the bounding box of the displayed image
 const lightboxFence = document.createElement('div');
 lightboxFence.setAttribute('id', 'lightbox-fence');
 
@@ -38,14 +50,19 @@ lightbox.appendChild(lightboxFence);
 
 lightboxWrapper.appendChild(lightbox);
 
+// Function to open the lightbox, set required properties and call functions
 function openLightbox(image, imageLabel) {
+    // TODO: some element selections could be improved by using the variables holding the elements instead of using getElementById or …byClass.
     document.getElementById('image-lightbox-wrapper').style.display = 'block';
     lightboxKillingFloor.style.display = 'block';
 
+    // Switch classes from in-article image to in-lightbox image
     image.classList.remove('image-in-content');
     image.classList.add('image-in-lightbox');
     image.classList.add('image-in-lb-fit-size');
 
+    // Remove image and label (<p>) elements from the lightbox element
+    // (this is used when user opens one image, closes it, and opens the lightbox again, possibly with another image in the page - the child elements need to be replaced)
     const lightboxChildren = lightbox.childNodes;
     lightboxChildren.forEach(child => {
         if (child.nodeName == 'IMG' || child.nodeName == 'P') {
@@ -53,9 +70,14 @@ function openLightbox(image, imageLabel) {
         }
     });
 
-    // Create label for the image and fill it with the alt text
+    // Create label for the image and fill it with the text found in the next sibling element; see the calling statement for details
     labelEl.innerHTML = (imageLabel);
 
+    // Set size of the displayed image
+    // I seem to have lost my train of thought and don't use the widths from herein. TODO - this should be refactored to avoid unneeded calculations
+    // If the image is SVG, we cannot depend on the "natural" width
+    // because that is an arbitrary value set by browsers and, at least in FF, it is too small -> set it to 90vw instead
+    // The lightbox has max-width and max-height of 90vw in case the image is bigger than user's viewport
     if (image.src.includes('.svg')) {
         lightboxWidth = '90vw';
         image.style.width = '90vw';
@@ -64,12 +86,17 @@ function openLightbox(image, imageLabel) {
         lightboxWidth = image.width + 'px';
     }
     document.getElementById('lightbox-fence').appendChild(image);
+
+    // Append image label to the lightbox (grand-parent of the image, parent is the fence)
     if (imageLabel) {
         image.parentNode.parentNode.appendChild(labelEl);
     }
+
+    // Display the lightbox by setting it to block and prevent the body to show scrollbars when lightbox open
     document.getElementById('image-lightbox').style.display = 'block';
     document.body.style.overflow = 'hidden';
 
+    // Set size of the displayed lightbox and the fence
     lightbox.style.width = image.clientWidth + 'px';
     lightbox.style.height = image.clientHeight + 'px';
 
@@ -78,10 +105,11 @@ function openLightbox(image, imageLabel) {
 
     // Make sure the label is not higher than the ( viewport height minus image height ) divided by two
     // The magical value of 50 is uncomfortable but needed.
-    // The solution is very suboptimal, it would be better to move the image higher and if that would not be enough, make it smaller.
+    // The solution is very suboptimal - TODO - it would be better to move the image higher and if that would not be enough, make it smaller.
     labelEl.style.maxHeight = (window.innerHeight - image.clientHeight - 30) / 2 + 'px';
 
     // Determine whether to allow zoom&pan - if the lightbox is of the same size as the image 100% size, then do not allow zoom&pan
+    // If zoom allowed, cal zoom function on double-click and double-touch
     if ((image.clientWidth < image.naturalWidth) || (image.clientHeight < image.naturalHeight)) {
         image.setAttribute('title', 'Double-click to toggle zoom');
         image.style.cursor = 'zoom-in';
@@ -99,6 +127,7 @@ function openLightbox(image, imageLabel) {
     // Improved double-tap/double-click handling
     let lastTapTime = 0;
 
+    // Count tapping is a double-tap if they occur less than 300ms apart
     function handleDoubleTap(e) {
         const currentTime = new Date().getTime();
         const tapLength = currentTime - lastTapTime;
@@ -113,10 +142,13 @@ function openLightbox(image, imageLabel) {
     }
 
     // Add both mouse and touch event listeners
+    // Note: Adding event listeners does not work as the events do not get fired if the lightbox is closed and opened again
+    // That is why we are using the ondblclick() abd ontouchend()
     // image.addEventListener('dblclick', handleDoubleTap);
     // image.addEventListener('touchend', handleDoubleTap);
 }
 
+// Handle events when lightbox is closed - hide the lightbox, wrapper, image, remove zoomed classes
 function closeLightbox() {
     let lightboxedImageToClose = document.getElementById('active-lightboxed-image');
     if (lightboxedImageToClose.classList.contains(zoomedSizeClass)) {
@@ -135,6 +167,9 @@ function closeLightbox() {
     event.stopPropagation();
 }
 
+// Handle zooming the image if allowed and setup panning support on mousedown
+// The image is zoomed to the center, the panning has to start there as well.
+// The top-left corner also must not be moved beyond the top-left corner of the fence and similarly with the bottom-right corner.
 function zoomImageInLightbox(boxedImage) {
     boxedImage.classList.toggle(fitSizeClass);
     boxedImage.classList.toggle(zoomedSizeClass);
@@ -153,6 +188,8 @@ function setupImagePanning(image) {
     let translateX = 0, translateY = 0;
 
     // Ensure initial translation is set up
+    // Since the panning position is set in pixels, the initial panning position means recalculate the translation(50%, 50%) to pixels,
+    // i.e., half the dimensions of the full-sized image
     if (!image.initialTranslation) {
         const rect = image.getBoundingClientRect();
         image.initialTranslation = {
@@ -255,6 +292,7 @@ function setupImagePanning(image) {
     });
 }
 
+// Remove control variables and event listeners used for panning
 function removeImagePanning(image) {
     if (image.panningListeners) {
         // Remove all stored event listeners
@@ -270,36 +308,44 @@ function removeImagePanning(image) {
     }
 }
 
-// Loop through each image
+// Loop through each image in the page
 images.forEach(img => {
-    // Create a new anchor element
+    // Create a new link element
     const link = document.createElement('a');
 
     // Remove the hardcoded width attribute which comes probably from the template and conflicts with the lightbox
-    // (and, in general, seems unneeded).
+    // (and, in general, is unneeded as we set responsive width for not-lightboxed in-content images).
     img.removeAttribute('width');
 
-    // Optionally, add a title or alt text
+    // Optionally, add a title from the alt text
     link.setAttribute('title', img.alt || '');
+
+    // New class for the lightboxable image links
     link.setAttribute('class', 'image-in-content-link');
 
+    // Create image label
+    // In our EvoDocs context, it is the content of the nextSibling element (which is the <p> right after the image);
+    // this is very specific for our Documentation and the declaration here needs to change should the template change
     let imageLabel = '';
     if (img.parentNode.nextElementSibling) {
         imageLabel = img.parentNode.nextElementSibling.innerHTML;
     }
 
-    // Add class
+    // New class for the lightboxable images
     img.setAttribute('class', 'image-in-content');
+
+    // Clone the image for the lightbox so that we can leave the properties of the original image as they were
     const imgInLB = img.cloneNode();
     imgInLB.setAttribute('id', 'active-lightboxed-image');
+
+    // Open the lightbox on mouse click
     img.addEventListener('click', function() {
         openLightbox(imgInLB, imageLabel);
     });
 
-    // Replace the image with the anchor element
+    // Replace the image with the link element
     img.parentNode.replaceChild(link, img);
 
-    // Append the image inside the anchor
+    // Append the image inside the link
     link.appendChild(img);
-    // link.appendChild(labelEl);
 });


### PR DESCRIPTION
I have come to the conclusion we need a comfortable lightbox for images in our Documentation to solve the issue that the images are either uselessly small or are links that open the image file, forcing readers to press the back button to get back to the article. Both cases are bad from the usability point of view.

So, I decided to write a small lightbox. I know there is plethora of lightboxes ready for use but I didn't feel like investigating which licence is compatible with ours and, moreover, I took it as an opportunity to learn a bit more about how to contritbute to our Docs not only by adding content, but also by helping with the functionality.

The lightbox is a couple of HTML elements, few SASS/CSS rules, and JavaScript, all strictly client-side. I have tested the functionality on Linux - Firefox & Brave, Android - Firefox & Brave, iPhone - Firefox & Safari (the latter only partially though because forcing hard-reload on Safari is [too much pain](https://www.reddit.com/r/ios/comments/1hfhmo9/hard_refresh_in_mobile_safari/).

I herein ask for a review of this PR a/ to verify it is OK for us to deploy this to the live Docs, b/ more importantly, to verify this will build successfully. I still feel I am missing a piece or two of the puzzle because when testing it on my local deployment, I sometimes had to manually copy the `_lightbox.sass` to `/home/edison23/gems/gems/evolveum-jekyll-theme-0.1.0/_sass/evolveum` and the `lightbox.js` to the built `docs/_site/assets/evolveum/` directories. Not always, though, so I'm not sure those instances were only me forgetting to run the `build.sh` script, or something else being wrong.

Also, I am aware certain parts of the JS (some element selections, in particular) and the label sizing handling approach are suboptimal and I intend to improve that, but I would first like to hear your thoughts if this is suitable for merge into master before I spend more time on it.

Thank you very much for your time! :)

P.S.: There are, currently, many instances of images that have links to themselves on them - when you click them, they open as described in the first paragraph here. For optimal functionality of the lightbox, these links need to be removed. I will take care of that if you approve this for merge. Essentially, though, these linked images behave the same as if the lightbox weren't there, nothing breaks.

P.P.S.: Good pages to see how the lightbox works are, e.g., these:

- [Resource wizard: Object type correlation - Evolveum Docs](https://docs.evolveum.com/midpoint/reference/support-4.9/admin-gui/resource-wizard/object-type/correlation/)  
- [Dashboards architecture - Evolveum Docs](https://docs.evolveum.com/midpoint/reference/support-4.9/admin-gui/dashboards/dashboard-architecture/) 
- [Advanced dashboard configuration options - Evolveum Docs](https://docs.evolveum.com/midpoint/reference/support-4.9/admin-gui/dashboards/configuration/) 
- [Delta visualization - Evolveum Docs](https://docs.evolveum.com/midpoint/reference/support-4.9/admin-gui/delta-visualization/)
- [Request access - Evolveum Docs](https://docs.evolveum.com/midpoint/reference/support-4.9/admin-gui/request-access/) 

