### PR TITLE
Change in-article max dimensions specs

### DIFF
--- a/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_lightbox.scss
@@ -1,16 +1,7 @@
 .image-in-content {
-  max-width: 30%;
+  max-height: 25rem;
+  max-width: 100%;
   cursor: pointer;
-
-  @media (max-width: 3000px) {
-    max-width: 35%;
-  }
-  @media (max-width: 2000px) {
-    max-width: 50%;
-  }
-  @media (max-width: 1280px) {
-    max-width: 100%;
-  }
 }
 
 td {


### PR DESCRIPTION
For in-article (non-lightboxed) images, the max-width is now set to 100% and the main limitation is set by max-height to prevent images breaking the flow of articles by taking too much spaces on the screen. I.e., wide images that are narrow height-wise can be full-width, but no image will take more than 25rem height-wise. This should improve visuals in general while keeping them sane in edge cases.