### PR TITLE
fix horizontal scroll caused by TOC

### DIFF
--- a/evolveum-jekyll-theme/_sass/evolveum/_asciidoc.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_asciidoc.scss
@@ -569,6 +569,7 @@ table.tableblock.fit-content>caption.title {
     margin-right: 20px;
     margin-bottom: 20px;
     width: max-content;
+    max-width: 100%;
     padding-left: 30px;
     padding-right: 30px;
     title {


### PR DESCRIPTION
The TOC had width set by content but did not had max width set. That meant the content did not wrap and caused horizontal scrolling on narrow devices (e.g., mobile). This commit adds the max width.