### PR TITLE
Improve/videoblock in article width

### DIFF
--- a/evolveum-jekyll-theme/_sass/evolveum/_base.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_base.scss
@@ -285,3 +285,9 @@ div.dt-container div.dt-layout-table>div {
 .dataTable {
     margin-bottom: 0rem !important;
 }
+
+.videoblock {
+  iframe {
+    width: 50rem;
+    aspect-ratio: 16/9;
+    max-width: 100%;

--- a/evolveum-jekyll-theme/_sass/evolveum/_base.scss
+++ b/evolveum-jekyll-theme/_sass/evolveum/_base.scss
@@ -291,3 +291,5 @@ div.dt-container div.dt-layout-table>div {
     width: 50rem;
     aspect-ratio: 16/9;
     max-width: 100%;
+  }
+}


### PR DESCRIPTION
Add sizing rules for embedded videos:

- width
- max-width
- aspect-ratio

The rules set the width of the `.videoblock` `<iframe>`, set its aspect ratio to 16:9 (arbitrarily picked as the "currently usual"), and sets its max. width to 100% to ensure x-asis auto-sizing (small viewports like mobile).

This addition improves usability and visual UX across the devices. Makes the use of manual sizing (e.g. `video::suo775ym_PE[youtube,title="Title",width="852",height="480"]`) superfluous (manual sizing is also rather harmful because it does not scale with the viewport).

The change is best show-cased on `/midpoint/methodology/first-steps/assessment/` (while the article still exists in its current form). There are not many videos used throughout the site elsewhere.