### PR TITLE
Lightbox/improve zoom handling

### DIFF
--- a/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
+++ b/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
@@ -226,9 +226,7 @@ function openLightbox(image, imageLabel) {
 // Handle events when lightbox is closed - hide the lightbox, wrapper, image, remove zoomed classes
 function closeLightbox() {
     let lightboxedImageToClose = document.getElementById('active-lightboxed-image');
-    if (lightboxedImageToClose.classList.contains(zoomedSizeClass)) {
-        removeImagePanning(lightboxedImageToClose);
-    }
+    removeImagePanning(lightboxedImageToClose);
     document.getElementById('image-lightbox-wrapper').style.animation = 'fadeOut 0.5s ease-out forwards';
     setTimeout(function() {
         lightboxedImageToClose.classList.remove(zoomedSizeClass);
@@ -307,7 +305,9 @@ function zoomImageByWheel(image, initialZoomScale, zoomDirection = 0) {
     if (currentZoomScale > 1) {
         // image.classList.remove(fitSizeClass);
         // image.classList.add(zoomedSizeClass);
-        setupImagePanning(image);
+        if (!isPanningUp) {
+            setupImagePanning(image);
+        }
     }
     else {
         removeImagePanning(image);
@@ -330,7 +330,14 @@ function manualZoom(image, initialZoomScale, zoomDirection) {
     }
 }
 
+// This global variable lets us know if the panning is set up already
+// and helps prevent us from setting it up multiple times on the same image.
+// Without this check, the panning calculations are doubled after repeated zoom-in/outs,
+// and the panning distance per mouse movement increases to the point of making it unusable.
+let isPanningUp = false;
+
 function setupImagePanning(image) {
+    isPanningUp = true;
     let isDragging = false;
     let startX, startY;
     let transformX = 0, transformY = 0;
@@ -455,6 +462,8 @@ function removeImagePanning(image) {
         });
 
         image.style.cursor = '';
+
+        isPanningUp = false;
 
         // Reset transform and remove stored translation
         image.style.transform = '';

--- a/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
+++ b/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
@@ -263,8 +263,8 @@ function zoomImageInLightbox(boxedImage) {
 }
 
 // zoomDirection:
-//  <1 means zoom in
-//  >1 means zoom out
+//  <0 means zoom in
+//  >0 means zoom out
 //      (Yes, the directions are reversed because that is what the mouse event sends and, by convention, we zoom in by wheel up.)
 //  ==2 means reset zoom
 //  The mouse wheel event typically sends ~60 in either direction constantly, the manual buttons in manualZoom() are set to send +/-1

--- a/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
+++ b/evolveum-jekyll-theme/assets/js/evolveum/lightboxize.js
@@ -262,31 +262,48 @@ function zoomImageInLightbox(boxedImage) {
     }
 }
 
+// zoomDirection:
+//  <1 means zoom in
+//  >1 means zoom out
+//      (Yes, the directions are reversed because that is what the mouse event sends and, by convention, we zoom in by wheel up.)
+//  ==2 means reset zoom
+//  The mouse wheel event typically sends ~60 in either direction constantly, the manual buttons in manualZoom() are set to send +/-1
 function zoomImageByWheel(image, initialZoomScale, zoomDirection = 0) {
+    // Arbitrarily chosen constant proven to zoom in/out by a reasonable step
     const zoomStep = 0.3;
+
+    // Default (direction not set) -> read the event deltaY value which is about 60 on either side
     if (zoomDirection == 0) {
         zoomDirection = event.deltaY;
     }
+    // Reset zoom
     else if (zoomDirection == 2) {
         currentZoomScale = initialZoomScale;
     }
 
-
+    // If zoom is not to be reset
     if (zoomDirection != 2) {
+        // If the zoom addition results in more than max zoom, set zoom to max
         if ((zoomDirection < 0) && (currentZoomScale + zoomStep >= 4)) {
             currentZoomScale = 4;
         }
+        // If there is still space too zoom in, do it
         else if ((zoomDirection < 0) && (currentZoomScale < 4)) {
             currentZoomScale += 0.3;
         }
+        // If there is still space to zoom out, do it
         else if (currentZoomScale - zoomStep > initialZoomScale) {
             currentZoomScale -= 0.3;
         }
+        // If the zoom subtraction results in less than initial scale, set initial scale.
+        // This is the last possible case so it needs not to be conditioned explicitly
         else {
             currentZoomScale = initialZoomScale;
         }
     }
 
+    // If the image is zoomed, set up panning (so that user can move around),
+    // otherwise, remove it
     if (currentZoomScale > 1) {
         // image.classList.remove(fitSizeClass);
         // image.classList.add(zoomedSizeClass);
@@ -296,6 +313,8 @@ function zoomImageByWheel(image, initialZoomScale, zoomDirection = 0) {
         removeImagePanning(image);
         // image.style.cursor = 'zoom-in';
     }
+
+    // And finally, set the image scale as calculated
     image.style.transform = 'scale(' + currentZoomScale + ')';
 }
 


### PR DESCRIPTION
- Make zoom by scroll more predictable
    - Zooming by mouse wheel now behaves better across various devices, especially touchpads. It is slower, less erratic, and easier to control (at least on the two touchpad devices I have at hand).
- Fix panning issue after several zoom-in/outs
    - Previously, when user zoomed by mouse in and out repeatedly, the panning step (the length by which the image moved on mouse move) increased to the point of making panning unusable. This is fixed now and the movement speed is consistent. 
    - On lower zoom levels, the panning speed is a tad too low, but I intend to fix that in future versions with the implementation of keeping the panned image origin fixed to mouse position (to make it as if the image is physically grabbed). 
- Document in-code the zoom by mouse wheel function
